### PR TITLE
fix #4: make compatible with Eclipse Juno or better

### DIFF
--- a/AutoDerivPlugin/META-INF/MANIFEST.MF
+++ b/AutoDerivPlugin/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: net.nodj.AutoDerivPlugin;singleton:=true
 Bundle-Version: 1.4.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.core.resources;bundle-version="3.9.1"
+ org.eclipse.core.resources;bundle-version="3.8.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: net.nodj.autoderivplugin,


### PR DESCRIPTION
Has been compiled against and tested with a Juno runtime. Nevertheless,
the project should use an explicit .target file to avoid such issues.