### PR TITLE
automatic module name for java 9 compatibility

### DIFF
--- a/AutoDerivPlugin/META-INF/MANIFEST.MF
+++ b/AutoDerivPlugin/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Export-Package: net.nodj.autoderivplugin,
  net.nodj.autoderivplugin.rules
 Bundle-Vendor: nodj
 Bundle-Activator: net.nodj.autoderivplugin.Activator
+Automatic-Module-Name: net.nodj.AutoDerivPlugin


### PR DESCRIPTION
https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers